### PR TITLE
Fix deprecated functions in master

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -38,14 +38,6 @@ jobs:
       matrix:
         include:
           - php: '7.3'
-            moodle-branch: 'MOODLE_310_STABLE'
-            database: 'mariadb'
-            node: '14.15'
-          - php: '7.3'
-            moodle-branch: 'MOODLE_310_STABLE'
-            database: 'pgsql'
-            node: '14.15'
-          - php: '7.3'
             moodle-branch: 'MOODLE_311_STABLE'
             database: 'mariadb'
             node: '14.15'

--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ The following maps the plugin version to use depending on your Moodle version.
 | ----------------- | ----------- |
 | Moodle 3.5 to 3.8 | MOODLE_35   |
 | Moodle 3.9        | MOODLE_39   |
-| Moodle 3.10+      | master      |
+| Moodle 3.10       | MOODLE_310  |
+| Moodle 3.11+      | master      |
 
 
 ## Plugin Installation ##

--- a/classes/output/quiz_user_table.php
+++ b/classes/output/quiz_user_table.php
@@ -99,9 +99,9 @@ class quiz_user_table extends table_sql implements renderable {
         $headers[] = get_string('fullname');
         $columns[] = 'fullname';
 
-        $extrafields = get_extra_user_fields($context);
+        $extrafields = \core\user_fields::get_identity_fields($context, false);
         foreach ($extrafields as $field) {
-            $headers[] = get_user_field_name($field);
+            $headers[] = \core\user_fields::get_display_name($field);
             $columns[] = $field;
         }
 

--- a/classes/output/student_search_table.php
+++ b/classes/output/student_search_table.php
@@ -107,9 +107,9 @@ class student_search_table extends table_sql implements renderable {
         $headers[] = get_string('fullname');
         $columns[] = 'fullname';
 
-        $extrafields = get_extra_user_fields($context);
+        $extrafields = \core\user_fields::get_identity_fields($context, false);
         foreach ($extrafields as $field) {
-            $headers[] = get_user_field_name($field);
+            $headers[] = \core\user_fields::get_display_name($field);
             $columns[] = $field;
         }
 


### PR DESCRIPTION
Hi @mattporritt 

This PR is created to fix deprecated functions. 

`$allowcustom` in `get_identity_fields` is false because new functions does not support custom user profile fields (MDL-70456).

Thank you.