### PR TITLE
Fix get_question_structure issue

### DIFF
--- a/classes/quiz.php
+++ b/classes/quiz.php
@@ -172,8 +172,9 @@ class quiz {
         $questions = new \stdClass();
         $types = array();
         $questioncount = 0;
+        $context = $this->get_quiz_context($quizid);
 
-        $questionsrecords = qbank_helper::get_question_structure($quizid);
+        $questionsrecords = qbank_helper::get_question_structure($quizid, $context);
 
         foreach ($questionsrecords as $questionrecord) {
             $types[] = get_string('pluginname', 'qtype_' . $questionrecord->qtype);


### PR DESCRIPTION
Fix error 

```
1) all_participants_inprogress_test::test_get_all_participants_inprogress_chart
ArgumentCountError: Too few arguments to function mod_quiz\question\bank\qbank_helper::get_question_structure(), 1 passed in /var/www/site/local/assessfreq/classes/quiz.php on line 176 and at least 2 expected
```
This is from https://github.com/moodle/moodle/commit/839cccead4127be770db3668a124b99e57d48395 - new parameter has been added to the function.