### PR TITLE
GitHub Actions for Moodle 4.0.

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -37,18 +37,14 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { moodle-branch: 'MOODLE_311_STABLE', php: '7.3', node: '14.15', database: 'mariadb' }
-          - { moodle-branch: 'MOODLE_311_STABLE', php: '7.3', node: '14.15', database: 'pgsql' }
-          - { moodle-branch: 'MOODLE_311_STABLE', php: '7.4', node: '14.15', database: 'mariadb' }
-          - { moodle-branch: 'MOODLE_311_STABLE', php: '7.4', node: '14.15', database: 'pgsql' }
-          - { moodle-branch: 'MOODLE_311_STABLE', php: '8.0', node: '14.15', database: 'mariadb' }
-          - { moodle-branch: 'MOODLE_311_STABLE', php: '8.0', node: '14.15', database: 'pgsql' }
+          - { moodle-branch: 'MOODLE_400_STABLE', php: '7.3', node: '14.15', database: 'mariadb' }
+          - { moodle-branch: 'MOODLE_400_STABLE', php: '7.3', node: '14.15', database: 'pgsql' }
+          - { moodle-branch: 'MOODLE_400_STABLE', php: '7.4', node: '14.15', database: 'mariadb' }
+          - { moodle-branch: 'MOODLE_400_STABLE', php: '7.4', node: '14.15', database: 'pgsql' }
           - { moodle-branch: 'master', php: '7.3', node: '14.15', database: 'mariadb' }
           - { moodle-branch: 'master', php: '7.3', node: '14.15', database: 'pgsql' }
           - { moodle-branch: 'master', php: '7.4', node: '14.15', database: 'mariadb' }
           - { moodle-branch: 'master', php: '7.4', node: '14.15', database: 'pgsql' }
-          - { moodle-branch: 'master', php: '8.0', node: '14.15', database: 'mariadb' }
-          - { moodle-branch: 'master', php: '8.0', node: '14.15', database: 'pgsql' }
     steps:
       - name: Check out repository code
         uses: actions/checkout@v2


### PR DESCRIPTION
Passing test without PHP 8.0 and 3.11 branch for Moodle 4.0 compatibility.