### PR TITLE
Moodle401 fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,14 +7,13 @@ Advanced assessment reporting for the Moodle LMS.
 ## Branches ##
 The following maps the plugin version to use depending on your Moodle version.
 
-| Moodle verion     | Branch      |
-| ----------------- | ----------- |
-| Moodle 3.5 to 3.8 | MOODLE_35   |
-| Moodle 3.9        | MOODLE_39   |
-| Moodle 3.10       | MOODLE_310  |
-| Moodle 3.11+      | MOODLE_311_STABLE  |
-| Moodle 4.0 and higher | MOODLE_400_STABLE  |
-
+| Moodle verion         | Branch            |
+| ----------------------| ------------------|
+| Moodle 3.5 to 3.8     | MOODLE_35         |
+| Moodle 3.9            | MOODLE_39         |
+| Moodle 3.10           | MOODLE_310        |
+| Moodle 3.11           | MOODLE_311_STABLE |
+| Moodle 4.0 and higher | MOODLE_400_STABLE |
 
 ## Plugin Installation ##
 The following steps will help you install this plugin into your Moodle instance.

--- a/tests/behat/assessmentfreq.feature
+++ b/tests/behat/assessmentfreq.feature
@@ -1,0 +1,103 @@
+@catalyst @javascript @local @local_assessfreq
+Feature: Assessment frequency
+
+  Background:
+    Given the following "courses" exist:
+      | shortname | fullname |
+      | C1        | Course 1 |
+    And the following "activities" exist:
+      | activity | course | name               | duedate                   |
+      | assign   | C1     | Test assignment 1  | ## January 1st, 2022 ##   |
+      | assign   | C1     | Test assignment 2  | ## February 1st, 2022 ##  |
+      | assign   | C1     | Test assignment 3  | ## March 1st, 2022 ##     |
+      | assign   | C1     | Test assignment 4  | ## April 1st, 2022 ##     |
+      | assign   | C1     | Test assignment 5  | ## May 1st, 2022 ##       |
+      | assign   | C1     | Test assignment 6  | ## June 1st, 2022 ##      |
+      | assign   | C1     | Test assignment 7  | ## July 1st, 2022 ##      |
+      | assign   | C1     | Test assignment 8  | ## August 1st, 2022 ##    |
+      | assign   | C1     | Test assignment 9  | ## September 1st, 2022 ## |
+      | assign   | C1     | Test assignment 10 | ## October 1st, 2022 ##   |
+    And the following "activities" exist:
+      | activity | course | name           | timeclose                 |
+      | choice   | C1     | Test choice 1  | ## January 1st, 2022 ##   |
+      | choice   | C1     | Test choice 2  | ## February 1st, 2022 ##  |
+      | choice   | C1     | Test choice 3  | ## March 1st, 2022 ##     |
+      | choice   | C1     | Test choice 4  | ## April 1st, 2022 ##     |
+      | choice   | C1     | Test choice 5  | ## May 1st, 2022 ##       |
+      | choice   | C1     | Test choice 6  | ## June 1st, 2022 ##      |
+      | choice   | C1     | Test choice 7  | ## July 1st, 2022 ##      |
+      | choice   | C1     | Test choice 8  | ## August 1st, 2022 ##    |
+      | choice   | C1     | Test choice 9  | ## September 1st, 2022 ## |
+    And the following "activities" exist:
+      | activity | course | name             | timeavailableto          |
+      | data     | C1     | Test database 1  | ## January 1st, 2022 ##  |
+      | data     | C1     | Test database 2  | ## February 1st, 2022 ## |
+      | data     | C1     | Test database 3  | ## March 1st, 2022 ##    |
+      | data     | C1     | Test database 4  | ## April 1st, 2022 ##    |
+      | data     | C1     | Test database 5  | ## May 1st, 2022 ##      |
+      | data     | C1     | Test database 6  | ## June 1st, 2022 ##     |
+      | data     | C1     | Test database 7  | ## July 1st, 2022 ##     |
+      | data     | C1     | Test database 8  | ## August 1st, 2022 ##   |
+    And the following "activities" exist:
+      | activity | course | name             | timeclose                |
+      | feedback | C1     | Test feedback 1  | ## January 1st, 2022 ##  |
+      | feedback | C1     | Test feedback 2  | ## February 1st, 2022 ## |
+      | feedback | C1     | Test feedback 3  | ## March 1st, 2022 ##    |
+      | feedback | C1     | Test feedback 4  | ## April 1st, 2022 ##    |
+      | feedback | C1     | Test feedback 5  | ## May 1st, 2022 ##      |
+      | feedback | C1     | Test feedback 6  | ## June 1st, 2022 ##     |
+      | feedback | C1     | Test feedback 7  | ## July 1st, 2022 ##     |
+    And the following "activities" exist:
+      | activity | course | name         | duedate                  |
+      | forum    | C1     | Test forum 1 | ## January 1st, 2022 ##  |
+      | forum    | C1     | Test forum 2 | ## February 1st, 2022 ## |
+      | forum    | C1     | Test forum 3 | ## March 1st, 2022 ##    |
+      | forum    | C1     | Test forum 4 | ## April 1st, 2022 ##    |
+      | forum    | C1     | Test forum 5 | ## May 1st, 2022 ##      |
+      | forum    | C1     | Test forum 6 | ## June 1st, 2022 ##     |
+    And the following "activities" exist:
+      | activity | course | name          | deadline                 |
+      | lesson   | C1     | Test lesson 1 | ## January 1st, 2022 ##  |
+      | lesson   | C1     | Test lesson 2 | ## February 1st, 2022 ## |
+      | lesson   | C1     | Test lesson 3 | ## March 1st, 2022 ##    |
+      | lesson   | C1     | Test lesson 4 | ## April 1st, 2022 ##    |
+      | lesson   | C1     | Test lesson 5 | ## May 1st, 2022 ##      |
+    And the following "activities" exist:
+      | activity | course | name        | timeclose                |
+      | quiz     | C1     | Test quiz 1 | ## January 1st, 2022 ##  |
+      | quiz     | C1     | Test quiz 2 | ## February 1st, 2022 ## |
+      | quiz     | C1     | Test quiz 3 | ## March 1st, 2022 ##    |
+      | quiz     | C1     | Test quiz 4 | ## April 1st, 2022 ##    |
+    And the following "activities" exist:
+      | activity | course | name         | timeclose                |
+      | scorm    | C1     | Test scorm 1 | ## January 1st, 2022 ##  |
+      | scorm    | C1     | Test scorm 2 | ## February 1st, 2022 ## |
+      | scorm    | C1     | Test scorm 3 | ## March 1st, 2022 ##    |
+    And the following "activities" exist:
+      | activity | course | name            | submissionend            |
+      | workshop | C1     | Test workshop 1 | ## January 1st, 2022 ##  |
+      | workshop | C1     | Test workshop 2 | ## February 1st, 2022 ## |
+    And the following config values are set as admin:
+      | config  | value                                                        | plugin           |
+      | modules | assign,choice,data,feedback,forum,lesson,quiz,scorm,workshop | local_assessfreq |
+
+  Scenario: Basic test of dashboard display
+    Given I log in as "admin"
+    When I navigate to "Plugins > Local plugins > Assessment Frequency > Clear history" in site administration
+    And I press "Reprocess all events"
+    And I press "Continue"
+    And I run all adhoc tasks
+    And I navigate to "Reports > Assessment reports > Assessment dashboard" in site administration
+    And I click on "Select year" "button" in the "local-assessfreq-report-heatmap" "region"
+    And I click on "2022" "link" in the "local-assessfreq-heatmap-year" "region"
+    And I click on "td[data-date='2022-1-1']" "css_element"
+    Then the following should exist in the "Title" table:
+     | Assignment: Test assignment 1 |
+     | Choice: Test choice 1         |
+     | Database: Test database 1     |
+     | Feedback: Test feedback 1     |
+     | Forum: Test forum 1           |
+     | Lesson: Test lesson 1         |
+     | Quiz: Test quiz 1             |
+     | SCORM package: test scorm 1   |
+     | Workshop: Test workshop 1     |

--- a/tests/external_test.php
+++ b/tests/external_test.php
@@ -22,12 +22,19 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or late
  */
 
+namespace local_assessfreq;
+
 defined('MOODLE_INTERNAL') || die();
+
+use assign;
+use context_module;
+use external_api;
+use local_assessfreq_external;
+use question_engine;
+use stdClass;
 
 global $CFG;
 require_once($CFG->dirroot . '/webservice/tests/helpers.php');
-
-use local_assessfreq\frequency;
 
 /**
  * This file contains the class that handles testing of the local assess webservice class.
@@ -35,8 +42,9 @@ use local_assessfreq\frequency;
  * @package    local_assessfreq
  * @copyright  2020 Matt Porritt <mattp@catalyst-au.net>
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or late
+ * @covers     \local_assessfreq_external
  */
-class external_testcase extends advanced_testcase {
+class external_test extends \advanced_testcase {
 
     /**
      *
@@ -171,14 +179,14 @@ class external_testcase extends advanced_testcase {
         }
 
         // Set up a couple of overrides.
-        $override1 = new \stdClass();
+        $override1 = new stdClass();
         $override1->quiz = $this->quiz1->id;
         $override1->userid = $user3->id;
         $override1->timeopen = 1593996000; // Open early.
         $override1->timeclose = 1594004400;
         $override1->timelimit = 7200;
 
-        $override2 = new \stdClass();
+        $override2 = new stdClass();
         $override2->quiz = $this->quiz1->id;
         $override2->userid = $user4->id;
         $override2->timeopen = 1593997200;
@@ -204,7 +212,7 @@ class external_testcase extends advanced_testcase {
         $this->setAdminUser();
 
         $duedate = 0;
-        $data = new \stdClass;
+        $data = new stdClass;
         $data->year  = 2020;
         $data->metric = 'assess'; // Can be assess or students.
         $data->modules = array('all');
@@ -281,7 +289,7 @@ class external_testcase extends advanced_testcase {
         $frequency->process_site_events(0);
         $frequency->process_user_events(0);
 
-        $data = new \stdClass;
+        $data = new stdClass;
         $data->date  = '2020-03-28';
         $data->modules = array('all');
 

--- a/tests/frequency_test.php
+++ b/tests/frequency_test.php
@@ -22,12 +22,18 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
+namespace local_assessfreq;
+
 defined('MOODLE_INTERNAL') || die();
+
+use assign;
+use cache;
+use context_module;
+use ReflectionMethod;
+use stdClass;
 
 global $CFG;
 require_once($CFG->dirroot . '/calendar/tests/helpers.php');
-
-use local_assessfreq\frequency;
 
 /**
  * This file contains the class that handles testing of the block assess frequency class.
@@ -35,8 +41,9 @@ use local_assessfreq\frequency;
  * @package    local_assessfreq
  * @copyright  2020 Matt Porritt <mattp@catalyst-au.net>
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @covers     \local_assessfreq\frequency
  */
-class frequency_testcase extends advanced_testcase {
+class frequency_test extends \advanced_testcase {
 
     /**
      *
@@ -500,7 +507,7 @@ class frequency_testcase extends advanced_testcase {
         global $DB;
 
         // Setup records in DB.
-        $lasrecord1 = new \stdClass();
+        $lasrecord1 = new stdClass();
         $lasrecord1->module = 'quiz';
         $lasrecord1->instanceid = 1;
         $lasrecord1->courseid = 2;
@@ -511,7 +518,7 @@ class frequency_testcase extends advanced_testcase {
         $lasrecord1->endmonth = 4;
         $lasrecord1->endday = 2;
 
-        $lasrecord2 = new \stdClass();
+        $lasrecord2 = new stdClass();
         $lasrecord2->module = 'quiz';
         $lasrecord2->instanceid = 2;
         $lasrecord2->courseid = 2;
@@ -522,7 +529,7 @@ class frequency_testcase extends advanced_testcase {
         $lasrecord2->endmonth = 4;
         $lasrecord2->endday = 3;
 
-        $lasrecord3 = new \stdClass();
+        $lasrecord3 = new stdClass();
         $lasrecord3->module = 'quiz';
         $lasrecord3->instanceid = 3;
         $lasrecord3->courseid = 2;
@@ -533,7 +540,7 @@ class frequency_testcase extends advanced_testcase {
         $lasrecord3->endmonth = 4;
         $lasrecord3->endday = 5;
 
-        $lasrecord4 = new \stdClass();
+        $lasrecord4 = new stdClass();
         $lasrecord4->module = 'quiz';
         $lasrecord4->instanceid = 4;
         $lasrecord4->courseid = 2;
@@ -544,7 +551,7 @@ class frequency_testcase extends advanced_testcase {
         $lasrecord4->endmonth = 4;
         $lasrecord4->endday = 6;
 
-        $lasrecord5 = new \stdClass();
+        $lasrecord5 = new stdClass();
         $lasrecord5->module = 'quiz';
         $lasrecord5->instanceid = 5;
         $lasrecord5->courseid = 2;
@@ -555,7 +562,7 @@ class frequency_testcase extends advanced_testcase {
         $lasrecord5->endmonth = 4;
         $lasrecord5->endday = 7;
 
-        $lasrecord6 = new \stdClass();
+        $lasrecord6 = new stdClass();
         $lasrecord6->module = 'assign';
         $lasrecord6->instanceid = 6;
         $lasrecord6->courseid = 2;
@@ -566,7 +573,7 @@ class frequency_testcase extends advanced_testcase {
         $lasrecord6->endmonth = 4;
         $lasrecord6->endday = 6;
 
-        $lasrecord7 = new \stdClass();
+        $lasrecord7 = new stdClass();
         $lasrecord7->module = 'quiz';
         $lasrecord7->instanceid = 7;
         $lasrecord7->courseid = 2;
@@ -597,7 +604,7 @@ class frequency_testcase extends advanced_testcase {
                     if ($userid == 789 && $record->instanceid == 3) {
                         continue;
                     }
-                    $userrecord = new \stdClass();
+                    $userrecord = new stdClass();
                     $userrecord->userid = $userid;
                     $userrecord->eventid = $eventid;
                     $DB->insert_record('local_assessfreq_user', $userrecord);
@@ -646,7 +653,7 @@ class frequency_testcase extends advanced_testcase {
                 continue;
             }
 
-            $record = new \stdClass();
+            $record = new stdClass();
             $record->module = 'quiz';
             $record->instanceid = $i;
             $record->courseid = $this->course->id;
@@ -726,7 +733,7 @@ class frequency_testcase extends advanced_testcase {
         // Every even month should have two entries and every odd month one entry.
         $records = array();
 
-        $lasrecord1 = new \stdClass();
+        $lasrecord1 = new stdClass();
         $lasrecord1->module = 'quiz';
         $lasrecord1->instanceid = 1;
         $lasrecord1->courseid = 2;
@@ -737,7 +744,7 @@ class frequency_testcase extends advanced_testcase {
         $lasrecord1->endmonth = 4;
         $lasrecord1->endday = 2;
 
-        $lasrecord2 = new \stdClass();
+        $lasrecord2 = new stdClass();
         $lasrecord2->module = 'quiz';
         $lasrecord2->instanceid = 2;
         $lasrecord2->courseid = 2;
@@ -748,7 +755,7 @@ class frequency_testcase extends advanced_testcase {
         $lasrecord2->endmonth = 4;
         $lasrecord2->endday = 3;
 
-        $lasrecord3 = new \stdClass();
+        $lasrecord3 = new stdClass();
         $lasrecord3->module = 'quiz';
         $lasrecord3->instanceid = 3;
         $lasrecord3->courseid = 2;
@@ -759,7 +766,7 @@ class frequency_testcase extends advanced_testcase {
         $lasrecord3->endmonth = 4;
         $lasrecord3->endday = 5;
 
-        $lasrecord4 = new \stdClass();
+        $lasrecord4 = new stdClass();
         $lasrecord4->module = 'quiz';
         $lasrecord4->instanceid = 4;
         $lasrecord4->courseid = 2;
@@ -823,7 +830,7 @@ class frequency_testcase extends advanced_testcase {
         // Every even month should have two entries and every odd month one entry.
         $records = array();
 
-        $lasrecord1 = new \stdClass();
+        $lasrecord1 = new stdClass();
         $lasrecord1->module = 'quiz';
         $lasrecord1->instanceid = 1;
         $lasrecord1->courseid = $this->course->id;
@@ -834,7 +841,7 @@ class frequency_testcase extends advanced_testcase {
         $lasrecord1->endmonth = 4;
         $lasrecord1->endday = 2;
 
-        $lasrecord2 = new \stdClass();
+        $lasrecord2 = new stdClass();
         $lasrecord2->module = 'assign';
         $lasrecord2->instanceid = 2;
         $lasrecord2->courseid = $this->course->id;
@@ -845,7 +852,7 @@ class frequency_testcase extends advanced_testcase {
         $lasrecord2->endmonth = 4;
         $lasrecord2->endday = 3;
 
-        $lasrecord3 = new \stdClass();
+        $lasrecord3 = new stdClass();
         $lasrecord3->module = 'assign';
         $lasrecord3->instanceid = 3;
         $lasrecord3->courseid = $this->course->id;
@@ -856,7 +863,7 @@ class frequency_testcase extends advanced_testcase {
         $lasrecord3->endmonth = 4;
         $lasrecord3->endday = 5;
 
-        $lasrecord4 = new \stdClass();
+        $lasrecord4 = new stdClass();
         $lasrecord4->module = 'forum';
         $lasrecord4->instanceid = 4;
         $lasrecord4->courseid = $this->course->id;
@@ -867,7 +874,7 @@ class frequency_testcase extends advanced_testcase {
         $lasrecord4->endmonth = 4;
         $lasrecord4->endday = 6;
 
-        $lasrecord5 = new \stdClass();
+        $lasrecord5 = new stdClass();
         $lasrecord5->module = 'forum';
         $lasrecord5->instanceid = 5;
         $lasrecord5->courseid = $this->course->id;
@@ -920,7 +927,7 @@ class frequency_testcase extends advanced_testcase {
         // Make some records to put in the database;
         // Every month should have an increasing ammount of users.
         for ($i = 1; $i <= 12; $i++) {
-            $record = new \stdClass();
+            $record = new stdClass();
             $record->module = 'quiz';
             $record->instanceid = $i;
             $record->courseid = $this->course->id;
@@ -934,7 +941,7 @@ class frequency_testcase extends advanced_testcase {
             $eventid = $DB->insert_record('local_assessfreq_site', $record, true);
 
             for ($j = 1; $j <= $i; $j++) {
-                $userrecord = new \stdClass();
+                $userrecord = new stdClass();
                 $userrecord->userid = $j;
                 $userrecord->eventid = $eventid;
 

--- a/tests/output/all_participants_inprogress_test.php
+++ b/tests/output/all_participants_inprogress_test.php
@@ -22,18 +22,19 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or late
  */
 
-defined('MOODLE_INTERNAL') || die();
+namespace local_assessfreq\output;
 
-use local_assessfreq\output\all_participants_inprogress;
+use stdClass;
 
 /**
  * This file contains the class that handles testing of the all participants in progress class.
  *
  * @package    local_assessfreq
  * @copyright  2020 Matt Porritt <mattp@catalyst-au.net>
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or late
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @covers     \local_assessfreq\output\all_participants_inprogress
  */
-class all_participants_inprogress_test extends advanced_testcase {
+class all_participants_inprogress_test extends \advanced_testcase {
 
     /**
      *
@@ -181,14 +182,14 @@ class all_participants_inprogress_test extends advanced_testcase {
         $generator->enrol_user($user6->id, $course->id, 'student');
 
         // Set up a couple of overrides.
-        $override1 = new \stdClass();
+        $override1 = new stdClass();
         $override1->quiz = $this->quiz3->id;
         $override1->userid = $user3->id;
         $override1->timeopen = 1593996000; // Open early.
         $override1->timeclose = 1594004400;
         $override1->timelimit = 7200;
 
-        $override2 = new \stdClass();
+        $override2 = new stdClass();
         $override2->quiz = $this->quiz4->id;
         $override2->userid = $user4->id;
         $override2->timeopen = 1593997200;
@@ -217,7 +218,7 @@ class all_participants_inprogress_test extends advanced_testcase {
     public function setup_quiz_tracking(int $now, int $quizid): void {
         global $DB;
 
-        $track1 = new \stdClass();
+        $track1 = new stdClass();
         $track1->assessid = $quizid;
         $track1->notloggedin = 5;
         $track1->loggedin = 0;
@@ -225,7 +226,7 @@ class all_participants_inprogress_test extends advanced_testcase {
         $track1->finished = 0;
         $track1->timecreated = $now + (60 * 1);
 
-        $track2 = new \stdClass();
+        $track2 = new stdClass();
         $track2->assessid = $quizid;
         $track2->notloggedin = 4;
         $track2->loggedin = 1;
@@ -233,7 +234,7 @@ class all_participants_inprogress_test extends advanced_testcase {
         $track2->finished = 0;
         $track2->timecreated = $now + (60 * 2);
 
-        $track3 = new \stdClass();
+        $track3 = new stdClass();
         $track3->assessid = $quizid;
         $track3->notloggedin = 3;
         $track3->loggedin = 2;
@@ -241,7 +242,7 @@ class all_participants_inprogress_test extends advanced_testcase {
         $track3->finished = 0;
         $track3->timecreated = $now + (60 * 3);
 
-        $track4 = new \stdClass();
+        $track4 = new stdClass();
         $track4->assessid = $quizid;
         $track4->notloggedin = 2;
         $track4->loggedin = 3;
@@ -249,7 +250,7 @@ class all_participants_inprogress_test extends advanced_testcase {
         $track4->finished = 0;
         $track4->timecreated = $now + (60 * 4);
 
-        $track5 = new \stdClass();
+        $track5 = new stdClass();
         $track5->assessid = $quizid;
         $track5->notloggedin = 1;
         $track5->loggedin = 4;

--- a/tests/output/assess_by_activity_test.php
+++ b/tests/output/assess_by_activity_test.php
@@ -22,18 +22,19 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or late
  */
 
-defined('MOODLE_INTERNAL') || die();
+namespace local_assessfreq\output;
 
-use local_assessfreq\output\assess_by_activity;
+use stdClass;
 
 /**
  * This file contains the class that handles testing of the assess by activity class.
  *
  * @package    local_assessfreq
  * @copyright  2020 Matt Porritt <mattp@catalyst-au.net>
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or late
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @covers     \local_assessfreq\output\assess_by_activity
  */
-class assess_by_activity_testcase extends advanced_testcase {
+class assess_by_activity_test extends \advanced_testcase {
 
     /**
      *
@@ -75,7 +76,7 @@ class assess_by_activity_testcase extends advanced_testcase {
         // Every even month should have two entries and every odd month one entry.
         $records = array();
 
-        $lasrecord1 = new \stdClass();
+        $lasrecord1 = new stdClass();
         $lasrecord1->module = 'quiz';
         $lasrecord1->instanceid = 1;
         $lasrecord1->courseid = $this->course->id;
@@ -86,7 +87,7 @@ class assess_by_activity_testcase extends advanced_testcase {
         $lasrecord1->endmonth = 4;
         $lasrecord1->endday = 2;
 
-        $lasrecord2 = new \stdClass();
+        $lasrecord2 = new stdClass();
         $lasrecord2->module = 'assign';
         $lasrecord2->instanceid = 2;
         $lasrecord2->courseid = $this->course->id;
@@ -97,7 +98,7 @@ class assess_by_activity_testcase extends advanced_testcase {
         $lasrecord2->endmonth = 4;
         $lasrecord2->endday = 3;
 
-        $lasrecord3 = new \stdClass();
+        $lasrecord3 = new stdClass();
         $lasrecord3->module = 'assign';
         $lasrecord3->instanceid = 3;
         $lasrecord3->courseid = $this->course->id;
@@ -108,7 +109,7 @@ class assess_by_activity_testcase extends advanced_testcase {
         $lasrecord3->endmonth = 4;
         $lasrecord3->endday = 5;
 
-        $lasrecord4 = new \stdClass();
+        $lasrecord4 = new stdClass();
         $lasrecord4->module = 'scorm';
         $lasrecord4->instanceid = 4;
         $lasrecord4->courseid = $this->course->id;
@@ -119,7 +120,7 @@ class assess_by_activity_testcase extends advanced_testcase {
         $lasrecord4->endmonth = 4;
         $lasrecord4->endday = 6;
 
-        $lasrecord5 = new \stdClass();
+        $lasrecord5 = new stdClass();
         $lasrecord5->module = 'scorm';
         $lasrecord5->instanceid = 5;
         $lasrecord5->courseid = $this->course->id;

--- a/tests/output/assess_by_month_student_test.php
+++ b/tests/output/assess_by_month_student_test.php
@@ -22,18 +22,19 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or late
  */
 
-defined('MOODLE_INTERNAL') || die();
+namespace local_assessfreq\output;
 
-use local_assessfreq\output\assess_by_month_student;
+use stdClass;
 
 /**
  * This file contains the class that handles testing of the assess by month class.
  *
  * @package    local_assessfreq
  * @copyright  2020 Matt Porritt <mattp@catalyst-au.net>
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or late
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @covers     \local_assessfreq\output\assess_by_month_student
  */
-class assess_by_month_student_testcase extends advanced_testcase {
+class assess_by_month_student_test extends \advanced_testcase {
 
     /**
      *
@@ -75,7 +76,7 @@ class assess_by_month_student_testcase extends advanced_testcase {
         // Make some records to put in the database;
         // Every month should have an increasing ammount of users.
         for ($i = 1; $i <= 12; $i++) {
-            $record = new \stdClass();
+            $record = new stdClass();
             $record->module = 'quiz';
             $record->instanceid = $i;
             $record->courseid = $this->course->id;
@@ -89,7 +90,7 @@ class assess_by_month_student_testcase extends advanced_testcase {
             $eventid = $DB->insert_record('local_assessfreq_site', $record, true);
 
             for ($j = 1; $j <= $i; $j++) {
-                $userrecord = new \stdClass();
+                $userrecord = new stdClass();
                 $userrecord->userid = $j;
                 $userrecord->eventid = $eventid;
 

--- a/tests/output/assess_by_month_test.php
+++ b/tests/output/assess_by_month_test.php
@@ -22,18 +22,19 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or late
  */
 
-defined('MOODLE_INTERNAL') || die();
+namespace local_assessfreq\output;
 
-use local_assessfreq\output\assess_by_month;
+use stdClass;
 
 /**
  * This file contains the class that handles testing of the assess by month class.
  *
  * @package    local_assessfreq
  * @copyright  2020 Matt Porritt <mattp@catalyst-au.net>
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or late
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @covers     \local_assessfreq\output\assess_by_month
  */
-class assess_by_month_testcase extends advanced_testcase {
+class assess_by_month_test extends \advanced_testcase {
 
     /**
      *
@@ -82,7 +83,7 @@ class assess_by_month_testcase extends advanced_testcase {
                 continue;
             }
 
-            $record = new \stdClass();
+            $record = new stdClass();
             $record->module = 'quiz';
             $record->instanceid = $i;
             $record->courseid = $this->course->id;

--- a/tests/output/participant_summary_test.php
+++ b/tests/output/participant_summary_test.php
@@ -22,18 +22,19 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or late
  */
 
-defined('MOODLE_INTERNAL') || die();
+namespace local_assessfreq\output;
 
-use local_assessfreq\output\participant_summary;
+use stdClass;
 
 /**
  * This file contains the class that handles testing of the participant summary class.
  *
  * @package    local_assessfreq
  * @copyright  2020 Matt Porritt <mattp@catalyst-au.net>
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or late
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @covers     \local_assessfreq\output\participant_summary
  */
-class participant_summary_testcase extends advanced_testcase {
+class participant_summary_test extends \advanced_testcase {
 
     /**
      *
@@ -50,7 +51,7 @@ class participant_summary_testcase extends advanced_testcase {
         global $DB;
         $now = 1594788000;
 
-        $track1 = new \stdClass();
+        $track1 = new stdClass();
         $track1->assessid = 123;
         $track1->notloggedin = 5;
         $track1->loggedin = 0;
@@ -58,7 +59,7 @@ class participant_summary_testcase extends advanced_testcase {
         $track1->finished = 0;
         $track1->timecreated = $now + (60 * 1);
 
-        $track2 = new \stdClass();
+        $track2 = new stdClass();
         $track2->assessid = 123;
         $track2->notloggedin = 4;
         $track2->loggedin = 1;
@@ -66,7 +67,7 @@ class participant_summary_testcase extends advanced_testcase {
         $track2->finished = 0;
         $track2->timecreated = $now + (60 * 2);
 
-        $track3 = new \stdClass();
+        $track3 = new stdClass();
         $track3->assessid = 123;
         $track3->notloggedin = 3;
         $track3->loggedin = 2;
@@ -74,7 +75,7 @@ class participant_summary_testcase extends advanced_testcase {
         $track3->finished = 0;
         $track3->timecreated = $now + (60 * 3);
 
-        $track4 = new \stdClass();
+        $track4 = new stdClass();
         $track4->assessid = 123;
         $track4->notloggedin = 2;
         $track4->loggedin = 3;
@@ -82,7 +83,7 @@ class participant_summary_testcase extends advanced_testcase {
         $track4->finished = 0;
         $track4->timecreated = $now + (60 * 4);
 
-        $track5 = new \stdClass();
+        $track5 = new stdClass();
         $track5->assessid = 123;
         $track5->notloggedin = 1;
         $track5->loggedin = 4;

--- a/tests/output/participant_trend_test.php
+++ b/tests/output/participant_trend_test.php
@@ -22,18 +22,19 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or late
  */
 
-defined('MOODLE_INTERNAL') || die();
+namespace local_assessfreq\output;
 
-use local_assessfreq\output\participant_trend;
+use stdClass;
 
 /**
  * This file contains the class that handles testing of the participant summary class.
  *
  * @package    local_assessfreq
  * @copyright  2020 Matt Porritt <mattp@catalyst-au.net>
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or late
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @covers     \local_assessfreq\output\participant_trend
  */
-class participant_trend_testcase extends advanced_testcase {
+class participant_trend_test extends \advanced_testcase {
 
     /**
      *
@@ -50,7 +51,7 @@ class participant_trend_testcase extends advanced_testcase {
         global $DB;
         $now = 1594788000;
 
-        $track1 = new \stdClass();
+        $track1 = new stdClass();
         $track1->assessid = 123;
         $track1->notloggedin = 5;
         $track1->loggedin = 0;
@@ -58,7 +59,7 @@ class participant_trend_testcase extends advanced_testcase {
         $track1->finished = 0;
         $track1->timecreated = $now + (60 * 1);
 
-        $track2 = new \stdClass();
+        $track2 = new stdClass();
         $track2->assessid = 123;
         $track2->notloggedin = 4;
         $track2->loggedin = 1;
@@ -66,7 +67,7 @@ class participant_trend_testcase extends advanced_testcase {
         $track2->finished = 0;
         $track2->timecreated = $now + (60 * 2);
 
-        $track3 = new \stdClass();
+        $track3 = new stdClass();
         $track3->assessid = 123;
         $track3->notloggedin = 3;
         $track3->loggedin = 2;
@@ -74,7 +75,7 @@ class participant_trend_testcase extends advanced_testcase {
         $track3->finished = 0;
         $track3->timecreated = $now + (60 * 3);
 
-        $track4 = new \stdClass();
+        $track4 = new stdClass();
         $track4->assessid = 123;
         $track4->notloggedin = 2;
         $track4->loggedin = 3;
@@ -82,7 +83,7 @@ class participant_trend_testcase extends advanced_testcase {
         $track4->finished = 0;
         $track4->timecreated = $now + (60 * 4);
 
-        $track5 = new \stdClass();
+        $track5 = new stdClass();
         $track5->assessid = 123;
         $track5->notloggedin = 1;
         $track5->loggedin = 4;

--- a/tests/output/quiz_user_table_test.php
+++ b/tests/output/quiz_user_table_test.php
@@ -22,9 +22,11 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-defined('MOODLE_INTERNAL') || die();
+namespace local_assessfreq\output;
 
-use local_assessfreq\output\quiz_user_table;
+use context_system;
+use quiz_attempt;
+use stdClass;
 
 /**
  * This file contains the class that handles testing of the block assess frequency class.
@@ -32,8 +34,9 @@ use local_assessfreq\output\quiz_user_table;
  * @package    local_assessfreq
  * @copyright  2020 Matt Porritt <mattp@catalyst-au.net>
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @covers     \local_assessfreq\output\quiz_user_table
  */
-class quiz_user_table_testcase extends advanced_testcase {
+class quiz_user_table_test extends \advanced_testcase {
 
     /**
      *
@@ -123,14 +126,14 @@ class quiz_user_table_testcase extends advanced_testcase {
         $generator->enrol_user($user4->id, $course->id, 'student');
 
         // Set up a couple of overrides.
-        $override1 = new \stdClass();
+        $override1 = new stdClass();
         $override1->quiz = $this->quiz1->id;
         $override1->userid = $user3->id;
         $override1->timeopen = 1593996000; // Open early.
         $override1->timeclose = 1594004400;
         $override1->timelimit = 7200;
 
-        $override2 = new \stdClass();
+        $override2 = new stdClass();
         $override2->quiz = $this->quiz1->id;
         $override2->userid = $user4->id;
         $override2->timeopen = 1593997200;
@@ -148,7 +151,7 @@ class quiz_user_table_testcase extends advanced_testcase {
 
         $CFG->sessiontimeout = 60 * 10;  // Short time out for test.
 
-        $record4 = new \stdClass();
+        $record4 = new stdClass();
         $record4->state = 0;
         $record4->sid = md5('sid4');
         $record4->sessdata = null;

--- a/tests/output/student_search_table_test.php
+++ b/tests/output/student_search_table_test.php
@@ -22,9 +22,12 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-defined('MOODLE_INTERNAL') || die();
+namespace local_assessfreq\output;
 
-use local_assessfreq\output\student_search_table;
+use question_engine;
+use quiz_attempt;
+use context_system;
+use stdClass;
 
 /**
  * This file contains the class that handles testing of the block assess frequency class.
@@ -32,8 +35,9 @@ use local_assessfreq\output\student_search_table;
  * @package    local_assessfreq
  * @copyright  2020 Matt Porritt <mattp@catalyst-au.net>
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @covers     \local_assessfreq\output\student_search_table
  */
-class student_search_table_testcase extends advanced_testcase {
+class student_search_table_test extends \advanced_testcase {
     /**
      *
      * @var stdClass $course Test course.
@@ -260,14 +264,14 @@ class student_search_table_testcase extends advanced_testcase {
         $generator->enrol_user($user6->id, $course->id, 'student');
 
         // Set up a couple of overrides.
-        $override1 = new \stdClass();
+        $override1 = new stdClass();
         $override1->quiz = $this->quiz1->id;
         $override1->userid = $user3->id;
         $override1->timeopen = 1593996000; // Open early.
         $override1->timeclose = 1594004400;
         $override1->timelimit = 7200;
 
-        $override2 = new \stdClass();
+        $override2 = new stdClass();
         $override2->quiz = $this->quiz1->id;
         $override2->userid = $user4->id;
         $override2->timeopen = 1593997200;
@@ -275,7 +279,7 @@ class student_search_table_testcase extends advanced_testcase {
         $override2->timelimit = 7200;
 
         // Start is more than one hour in the past, but end is in the future. (Should return).
-        $override3 = new \stdClass();
+        $override3 = new stdClass();
         $override3->quiz = 3; // OK to use fake id for this.
         $override3->userid = 5; // OK to use fake id for this.
         $override3->timeopen = ($now - (3600 * 2));
@@ -283,7 +287,7 @@ class student_search_table_testcase extends advanced_testcase {
         $override3->timelimit = 3600;
 
         // Start is less than one hour in the past, but end is in the future. (Should return).
-        $override4 = new \stdClass();
+        $override4 = new stdClass();
         $override4->quiz = 4; // OK to use fake id for this.
         $override4->userid = 6; // OK to use fake id for this.
         $override4->timeopen = ($now - (3600 * 0.5));
@@ -291,7 +295,7 @@ class student_search_table_testcase extends advanced_testcase {
         $override4->timelimit = 3600;
 
         // Start is less than one hour in the future, end is more than one hour in the future. (Should return).
-        $override5 = new \stdClass();
+        $override5 = new stdClass();
         $override5->quiz = 5; // OK to use fake id for this.
         $override5->userid = 7; // OK to use fake id for this.
         $override5->timeopen = ($now + (3600 * 0.5));
@@ -299,7 +303,7 @@ class student_search_table_testcase extends advanced_testcase {
         $override5->timelimit = 3600;
 
         // Start is less than one hour in the future, end is less that one hour in the future. (Should return).
-        $override6 = new \stdClass();
+        $override6 = new stdClass();
         $override6->quiz = 6; // OK to use fake id for this.
         $override6->userid = 8; // OK to use fake id for this.
         $override6->timeopen = ($now + (3600 * 0.25));
@@ -307,7 +311,7 @@ class student_search_table_testcase extends advanced_testcase {
         $override6->timelimit = 1800;
 
         // Start is more than one hour in the future, end is more than one hour in the future. (Should not return).
-        $override7 = new \stdClass();
+        $override7 = new stdClass();
         $override7->quiz = 7; // OK to use fake id for this.
         $override7->userid = 9; // OK to use fake id for this.
         $override7->timeopen = ($now + (3600 * 2));
@@ -315,7 +319,7 @@ class student_search_table_testcase extends advanced_testcase {
         $override7->timelimit = 3600;
 
         // Start and end date of override is more than one hour in the past. (Should not be returned).
-        $override8 = new \stdClass();
+        $override8 = new stdClass();
         $override8->quiz = 1; // OK to use fake id for this.
         $override8->userid = 3; // OK to use fake id for this.
         $override8->timeopen = ($now - (3600 * 3));
@@ -323,7 +327,7 @@ class student_search_table_testcase extends advanced_testcase {
         $override8->timelimit = 3600;
 
         // Start is more than one hour in the past, but end is less than one hour in the past. (Should return).
-        $override9 = new \stdClass();
+        $override9 = new stdClass();
         $override9->quiz = 2; // OK to use fake id for this.
         $override9->userid = 4; // OK to use fake id for this.
         $override9->timeopen = ($now - (3600 * 2));
@@ -345,7 +349,7 @@ class student_search_table_testcase extends advanced_testcase {
 
         $CFG->sessiontimeout = 60 * 10;  // Short time out for test.
 
-        $record1 = new \stdClass();
+        $record1 = new stdClass();
         $record1->state = 0;
         $record1->sid = md5('sid1');
         $record1->sessdata = null;
@@ -355,7 +359,7 @@ class student_search_table_testcase extends advanced_testcase {
         $record1->firstip = '10.0.0.1';
         $record1->lastip = '10.0.0.1';
 
-        $record2 = new \stdClass();
+        $record2 = new stdClass();
         $record2->state = 0;
         $record2->sid = md5('sid2');
         $record2->sessdata = null;
@@ -365,7 +369,7 @@ class student_search_table_testcase extends advanced_testcase {
         $record2->firstip = '10.0.0.1';
         $record2->lastip = '10.0.0.1';
 
-        $record3 = new \stdClass();
+        $record3 = new stdClass();
         $record3->state = 0;
         $record3->sid = md5('sid3');
         $record3->sessdata = null;
@@ -375,7 +379,7 @@ class student_search_table_testcase extends advanced_testcase {
         $record3->firstip = '10.0.0.1';
         $record3->lastip = '10.0.0.1';
 
-        $record4 = new \stdClass();
+        $record4 = new stdClass();
         $record4->state = 0;
         $record4->sid = md5('sid4');
         $record4->sessdata = null;
@@ -385,7 +389,7 @@ class student_search_table_testcase extends advanced_testcase {
         $record4->firstip = '10.0.0.1';
         $record4->lastip = '10.0.0.1';
 
-        $record5 = new \stdClass();
+        $record5 = new stdClass();
         $record5->state = 0;
         $record5->sid = md5('sid5');
         $record5->sessdata = null;
@@ -395,7 +399,7 @@ class student_search_table_testcase extends advanced_testcase {
         $record5->firstip = '10.0.0.1';
         $record5->lastip = '10.0.0.1';
 
-        $record6 = new \stdClass();
+        $record6 = new stdClass();
         $record6->state = 0;
         $record6->sid = md5('sid6');
         $record6->sessdata = null;

--- a/tests/output/upcomming_quizzes_test.php
+++ b/tests/output/upcomming_quizzes_test.php
@@ -22,9 +22,9 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or late
  */
 
-defined('MOODLE_INTERNAL') || die();
+namespace local_assessfreq\output;
 
-use local_assessfreq\output\upcomming_quizzes;
+use stdClass;
 
 /**
  * This file contains the class that handles testing of the upcomming quizzes class.
@@ -32,8 +32,9 @@ use local_assessfreq\output\upcomming_quizzes;
  * @package    local_assessfreq
  * @copyright  2020 Matt Porritt <mattp@catalyst-au.net>
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or late
+ * @covers     \local_assessfreq\output\upcomming_quizzes
  */
-class upcomming_quizzes_test extends advanced_testcase {
+class upcomming_quizzes_test extends \advanced_testcase {
 
     /**
      *
@@ -181,14 +182,14 @@ class upcomming_quizzes_test extends advanced_testcase {
         $generator->enrol_user($user6->id, $course->id, 'student');
 
         // Set up a couple of overrides.
-        $override1 = new \stdClass();
+        $override1 = new stdClass();
         $override1->quiz = $this->quiz3->id;
         $override1->userid = $user3->id;
         $override1->timeopen = 1593996000; // Open early.
         $override1->timeclose = 1594004400;
         $override1->timelimit = 7200;
 
-        $override2 = new \stdClass();
+        $override2 = new stdClass();
         $override2->quiz = $this->quiz4->id;
         $override2->userid = $user4->id;
         $override2->timeopen = 1593997200;

--- a/tests/quiz_test.php
+++ b/tests/quiz_test.php
@@ -22,10 +22,11 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-defined('MOODLE_INTERNAL') || die();
+namespace local_assessfreq;
 
-use local_assessfreq\quiz;
-use core_calendar\local\event\proxies\std_proxy;
+use question_engine;
+use quiz_attempt;
+use stdClass;
 
 /**
  * This file contains the class that handles testing of the block assess frequency class.
@@ -33,8 +34,9 @@ use core_calendar\local\event\proxies\std_proxy;
  * @package    local_assessfreq
  * @copyright  2020 Matt Porritt <mattp@catalyst-au.net>
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @covers     \local_assessfreq\quiz
  */
-class quiz_testcase extends advanced_testcase {
+class quiz_test extends \advanced_testcase {
 
     /**
      *
@@ -262,14 +264,14 @@ class quiz_testcase extends advanced_testcase {
         $generator->enrol_user($user6->id, $course->id, 'student');
 
         // Set up a couple of overrides.
-        $override1 = new \stdClass();
+        $override1 = new stdClass();
         $override1->quiz = $this->quiz1->id;
         $override1->userid = $user3->id;
         $override1->timeopen = 1593996000; // Open early.
         $override1->timeclose = 1594004400;
         $override1->timelimit = 7200;
 
-        $override2 = new \stdClass();
+        $override2 = new stdClass();
         $override2->quiz = $this->quiz1->id;
         $override2->userid = $user4->id;
         $override2->timeopen = 1593997200;
@@ -277,7 +279,7 @@ class quiz_testcase extends advanced_testcase {
         $override2->timelimit = 7200;
 
         // Start is more than one hour in the past, but end is in the future. (Should return).
-        $override3 = new \stdClass();
+        $override3 = new stdClass();
         $override3->quiz = 3; // OK to use fake id for this.
         $override3->userid = 5; // OK to use fake id for this.
         $override3->timeopen = ($now - (3600 * 2));
@@ -285,7 +287,7 @@ class quiz_testcase extends advanced_testcase {
         $override3->timelimit = 3600;
 
         // Start is less than one hour in the past, but end is in the future. (Should return).
-        $override4 = new \stdClass();
+        $override4 = new stdClass();
         $override4->quiz = 4; // OK to use fake id for this.
         $override4->userid = 6; // OK to use fake id for this.
         $override4->timeopen = ($now - (3600 * 0.5));
@@ -293,7 +295,7 @@ class quiz_testcase extends advanced_testcase {
         $override4->timelimit = 3600;
 
         // Start is less than one hour in the future, end is more than one hour in the future. (Should return).
-        $override5 = new \stdClass();
+        $override5 = new stdClass();
         $override5->quiz = 5; // OK to use fake id for this.
         $override5->userid = 7; // OK to use fake id for this.
         $override5->timeopen = ($now + (3600 * 0.5));
@@ -301,7 +303,7 @@ class quiz_testcase extends advanced_testcase {
         $override5->timelimit = 3600;
 
         // Start is less than one hour in the future, end is less that one hour in the future. (Should return).
-        $override6 = new \stdClass();
+        $override6 = new stdClass();
         $override6->quiz = 6; // OK to use fake id for this.
         $override6->userid = 8; // OK to use fake id for this.
         $override6->timeopen = ($now + (3600 * 0.25));
@@ -309,7 +311,7 @@ class quiz_testcase extends advanced_testcase {
         $override6->timelimit = 1800;
 
         // Start is more than one hour in the future, end is more than one hour in the future. (Should not return).
-        $override7 = new \stdClass();
+        $override7 = new stdClass();
         $override7->quiz = 7; // OK to use fake id for this.
         $override7->userid = 9; // OK to use fake id for this.
         $override7->timeopen = ($now + (3600 * 2));
@@ -317,7 +319,7 @@ class quiz_testcase extends advanced_testcase {
         $override7->timelimit = 3600;
 
         // Start and end date of override is more than one hour in the past. (Should not be returned).
-        $override8 = new \stdClass();
+        $override8 = new stdClass();
         $override8->quiz = 1; // OK to use fake id for this.
         $override8->userid = 3; // OK to use fake id for this.
         $override8->timeopen = ($now - (3600 * 3));
@@ -325,7 +327,7 @@ class quiz_testcase extends advanced_testcase {
         $override8->timelimit = 3600;
 
         // Start is more than one hour in the past, but end is less than one hour in the past. (Should return).
-        $override9 = new \stdClass();
+        $override9 = new stdClass();
         $override9->quiz = 2; // OK to use fake id for this.
         $override9->userid = 4; // OK to use fake id for this.
         $override9->timeopen = ($now - (3600 * 2));
@@ -347,7 +349,7 @@ class quiz_testcase extends advanced_testcase {
 
         $CFG->sessiontimeout = 60 * 10;  // Short time out for test.
 
-        $record1 = new \stdClass();
+        $record1 = new stdClass();
         $record1->state = 0;
         $record1->sid = md5('sid1');
         $record1->sessdata = null;
@@ -357,7 +359,7 @@ class quiz_testcase extends advanced_testcase {
         $record1->firstip = '10.0.0.1';
         $record1->lastip = '10.0.0.1';
 
-        $record2 = new \stdClass();
+        $record2 = new stdClass();
         $record2->state = 0;
         $record2->sid = md5('sid2');
         $record2->sessdata = null;
@@ -367,7 +369,7 @@ class quiz_testcase extends advanced_testcase {
         $record2->firstip = '10.0.0.1';
         $record2->lastip = '10.0.0.1';
 
-        $record3 = new \stdClass();
+        $record3 = new stdClass();
         $record3->state = 0;
         $record3->sid = md5('sid3');
         $record3->sessdata = null;
@@ -377,7 +379,7 @@ class quiz_testcase extends advanced_testcase {
         $record3->firstip = '10.0.0.1';
         $record3->lastip = '10.0.0.1';
 
-        $record4 = new \stdClass();
+        $record4 = new stdClass();
         $record4->state = 0;
         $record4->sid = md5('sid4');
         $record4->sessdata = null;
@@ -387,7 +389,7 @@ class quiz_testcase extends advanced_testcase {
         $record4->firstip = '10.0.0.1';
         $record4->lastip = '10.0.0.1';
 
-        $record5 = new \stdClass();
+        $record5 = new stdClass();
         $record5->state = 0;
         $record5->sid = md5('sid5');
         $record5->sessdata = null;
@@ -397,7 +399,7 @@ class quiz_testcase extends advanced_testcase {
         $record5->firstip = '10.0.0.1';
         $record5->lastip = '10.0.0.1';
 
-        $record6 = new \stdClass();
+        $record6 = new stdClass();
         $record6->state = 0;
         $record6->sid = md5('sid6');
         $record6->sessdata = null;
@@ -460,7 +462,7 @@ class quiz_testcase extends advanced_testcase {
     public function setup_quiz_tracking(int $now, int $quizid): void {
         global $DB;
 
-        $track1 = new \stdClass();
+        $track1 = new stdClass();
         $track1->assessid = $quizid;
         $track1->notloggedin = 5;
         $track1->loggedin = 0;
@@ -468,7 +470,7 @@ class quiz_testcase extends advanced_testcase {
         $track1->finished = 0;
         $track1->timecreated = $now + (60 * 1);
 
-        $track2 = new \stdClass();
+        $track2 = new stdClass();
         $track2->assessid = $quizid;
         $track2->notloggedin = 4;
         $track2->loggedin = 1;
@@ -476,7 +478,7 @@ class quiz_testcase extends advanced_testcase {
         $track2->finished = 0;
         $track2->timecreated = $now + (60 * 2);
 
-        $track3 = new \stdClass();
+        $track3 = new stdClass();
         $track3->assessid = $quizid;
         $track3->notloggedin = 3;
         $track3->loggedin = 2;
@@ -484,7 +486,7 @@ class quiz_testcase extends advanced_testcase {
         $track3->finished = 0;
         $track3->timecreated = $now + (60 * 3);
 
-        $track4 = new \stdClass();
+        $track4 = new stdClass();
         $track4->assessid = $quizid;
         $track4->notloggedin = 2;
         $track4->loggedin = 3;
@@ -492,7 +494,7 @@ class quiz_testcase extends advanced_testcase {
         $track4->finished = 0;
         $track4->timecreated = $now + (60 * 4);
 
-        $track5 = new \stdClass();
+        $track5 = new stdClass();
         $track5->assessid = $quizid;
         $track5->notloggedin = 1;
         $track5->loggedin = 4;
@@ -686,7 +688,7 @@ class quiz_testcase extends advanced_testcase {
 
         // Add an extra override for this test.
         // Start is less than one hour in the past, but end is in the future. (Should return).
-        $override = new \stdClass();
+        $override = new stdClass();
         $override->quiz = $this->quiz4->id; // OK to use fake id for this.
         $override->userid = 7; // OK to use fake id for this.
         $override->timeopen = ($now - (3600 * 0.75));

--- a/version.php
+++ b/version.php
@@ -25,8 +25,9 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'local_assessfreq';
-$plugin->release = '2021101500';
-$plugin->version = 2021101500;
+$plugin->release = '2023020700';
+$plugin->version = 2023020700;
 $plugin->requires = 2022041906; // Requires 4.0
-$plugin->supports = [400, 400];
+$plugin->supports = [400, 401];
 $plugin->maturity = MATURITY_STABLE;
+


### PR DESCRIPTION
Fixes #128 

Before merging to `master`, we will need to create a new `MOODLE_311` branch to maintain 3.11-4.0 support, the 4.1 changes are not backwards-compatible due to changes in the core database schema. I have included an update to the README to reflect this.

As well as fixing the quiz questions query, I have updated the unit tests to meet current naming and namespacing conventions. I have also added a very basic behat test, mainly to provide an easy way of setting up a test scenario so the reports can be easily checked on future versions.