### PR TITLE
Fix array merge exception on return from get_user_events_all

### DIFF
--- a/classes/frequency.php
+++ b/classes/frequency.php
@@ -1219,7 +1219,10 @@ class frequency {
         } else {
             // Work through the event array.
             foreach ($modules as $module) {
-                $events = array_merge($events, $this->$functionname($module, $from, $to));
+                $records = $this->$functionname($module, $from, $to);
+                foreach ($records as $record) {
+                    $events[] = $record;
+                }
             }
         }
 

--- a/history.php
+++ b/history.php
@@ -49,7 +49,7 @@ if ($action === null) {
     $actionurl = new moodle_url('/local/assessfreq/history.php', array('action' => 'confirmed'));
     $cancelurl = new moodle_url('/local/assessfreq/history.php');
     echo $OUTPUT->confirm(get_string('confirmreprocess', 'local_assessfreq'),
-        new single_button($actionurl, get_string('continue'), 'post', true),
+        new single_button($actionurl, get_string('continue'), 'post', single_button::BUTTON_SECONDARY),
         new single_button($cancelurl, get_string('cancel'), 'get'));
 
 } else if ($action == 'confirmed') {


### PR DESCRIPTION
get_user_events_all returns a database record causing exception on array_merge. When functionname is get_user_events_all it returns an iterator rather than array which is typically a mysql or pgsql record type. This triggers the exception. This change populates the events array with instances of database record for iteration later on.
There may be a similar issue on
https://github.com/catalyst-marcus-green/moodle-local_assessfreq/blob/7a4959f62d9fec892d44dcd64d9f66f820c3d466/classes/frequency.php#L1299
But I will leave that to a later update.

Single button was throwing a deprecation error in the behat test and is only to do with ensuring the tests pass.

There are other unrelated behat failures that have not worked in quite a long time.