### PR TITLE
WR421526:Removed MOODLE_INTERNAL_CHECKS for standards compliance

### DIFF
--- a/classes/event/event_processed.php
+++ b/classes/event/event_processed.php
@@ -24,8 +24,6 @@
 
 namespace local_assessfreq\event;
 
-defined('MOODLE_INTERNAL') || die();
-
 /**
  * Event class.
  *

--- a/classes/output/all_participants_inprogress.php
+++ b/classes/output/all_participants_inprogress.php
@@ -26,8 +26,6 @@ namespace local_assessfreq\output;
 
 use local_assessfreq\quiz;
 
-defined('MOODLE_INTERNAL') || die;
-
 /**
  * Renderable for all participant summary card.
  *

--- a/classes/output/assess_by_activity.php
+++ b/classes/output/assess_by_activity.php
@@ -26,8 +26,6 @@ namespace local_assessfreq\output;
 
 use local_assessfreq\frequency;
 
-defined('MOODLE_INTERNAL') || die;
-
 /**
  * Renderable for assessments by activity card.
  *

--- a/classes/output/assess_by_month.php
+++ b/classes/output/assess_by_month.php
@@ -26,8 +26,6 @@ namespace local_assessfreq\output;
 
 use local_assessfreq\frequency;
 
-defined('MOODLE_INTERNAL') || die;
-
 /**
  * Renderable for assessments due by month card.
  *

--- a/classes/output/assess_by_month_student.php
+++ b/classes/output/assess_by_month_student.php
@@ -26,8 +26,6 @@ namespace local_assessfreq\output;
 
 use local_assessfreq\frequency;
 
-defined('MOODLE_INTERNAL') || die;
-
 /**
  * Renderable for assessments due by month student card.
  *

--- a/classes/output/inprogress_participant_summary.php
+++ b/classes/output/inprogress_participant_summary.php
@@ -24,8 +24,6 @@
 
 namespace local_assessfreq\output;
 
-defined('MOODLE_INTERNAL') || die;
-
 /**
  * Renderable for participant summary card.
  *

--- a/classes/output/participant_summary.php
+++ b/classes/output/participant_summary.php
@@ -26,8 +26,6 @@ namespace local_assessfreq\output;
 
 use local_assessfreq\quiz;
 
-defined('MOODLE_INTERNAL') || die;
-
 /**
  * Renderable for participant summary card.
  *

--- a/classes/output/participant_trend.php
+++ b/classes/output/participant_trend.php
@@ -26,8 +26,6 @@ namespace local_assessfreq\output;
 
 use local_assessfreq\quiz;
 
-defined('MOODLE_INTERNAL') || die;
-
 /**
  * Renderable for participant trend card.
  *

--- a/classes/output/renderer.php
+++ b/classes/output/renderer.php
@@ -25,8 +25,6 @@ namespace local_assessfreq\output;
 
 use local_assessfreq\quiz;
 
-defined('MOODLE_INTERNAL') || die;
-
 use plugin_renderer_base;
 use local_assessfreq\frequency;
 

--- a/classes/output/upcomming_quizzes.php
+++ b/classes/output/upcomming_quizzes.php
@@ -26,8 +26,6 @@ namespace local_assessfreq\output;
 
 use local_assessfreq\quiz;
 
-defined('MOODLE_INTERNAL') || die;
-
 /**
  * Renderable for upcomming quizzes card.
  *

--- a/classes/privacy/provider.php
+++ b/classes/privacy/provider.php
@@ -24,8 +24,6 @@
 
 namespace local_assessfreq\privacy;
 
-defined('MOODLE_INTERNAL') || die();
-
 use core_privacy\local\metadata\collection;
 use core_privacy\local\request\contextlist;
 use core_privacy\local\request\approved_contextlist;

--- a/classes/quiz.php
+++ b/classes/quiz.php
@@ -26,8 +26,6 @@ namespace local_assessfreq;
 
 use mod_quiz\question\bank\qbank_helper;
 
-defined('MOODLE_INTERNAL') || die();
-
 /**
  * Quiz data class.
  *

--- a/classes/task/data_process.php
+++ b/classes/task/data_process.php
@@ -25,8 +25,6 @@ namespace local_assessfreq\task;
 
 use core\task\scheduled_task;
 
-defined('MOODLE_INTERNAL') || die();
-
 /**
  * A scheduled task to generate data used in plugin reports.
  *

--- a/classes/task/history_process.php
+++ b/classes/task/history_process.php
@@ -25,8 +25,6 @@ namespace local_assessfreq\task;
 
 use core\task\adhoc_task;
 
-defined('MOODLE_INTERNAL') || die();
-
 /**
  * Adhoc task to process historical data used in plugin.
  *

--- a/classes/task/quiz_tracking.php
+++ b/classes/task/quiz_tracking.php
@@ -25,8 +25,6 @@ namespace local_assessfreq\task;
 
 use core\task\scheduled_task;
 
-defined('MOODLE_INTERNAL') || die();
-
 /**
  * A scheduled task to track the process of quizzes in the system.
  *

--- a/classes/utils.php
+++ b/classes/utils.php
@@ -24,8 +24,6 @@
 
 namespace local_assessfreq;
 
-defined('MOODLE_INTERNAL') || die();
-
 /**
  * Utils class.
  *

--- a/db/install.php
+++ b/db/install.php
@@ -22,8 +22,6 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-defined('MOODLE_INTERNAL') || die();
-
 /**
  * Generate ad-hoc task on install.
  */

--- a/lib.php
+++ b/lib.php
@@ -22,8 +22,6 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-defined('MOODLE_INTERNAL') || die();
-
 
 /**
  * Returns the name of the user preferences as well as the details this plugin uses.

--- a/tests/external_test.php
+++ b/tests/external_test.php
@@ -24,8 +24,6 @@
 
 namespace local_assessfreq;
 
-defined('MOODLE_INTERNAL') || die();
-
 use assign;
 use context_module;
 use external_api;

--- a/version.php
+++ b/version.php
@@ -27,7 +27,7 @@ defined('MOODLE_INTERNAL') || die();
 $plugin->component = 'local_assessfreq';
 $plugin->release = '2023102700';
 $plugin->version = 2023102700;
-$plugin->requires = 2023042400; // Requires 4.2
+$plugin->requires = 2023042400; // Requires 4.2.
 $plugin->supports = [402, 402];
 $plugin->maturity = MATURITY_STABLE;
 


### PR DESCRIPTION
Coding standards changed and these checks were cluttering the ci linting, making it hard to see "real" issues.