### PR TITLE
Fix quiz compatibility with backported MDL-80300

### DIFF
--- a/classes/form/quiz_override_form.php
+++ b/classes/form/quiz_override_form.php
@@ -27,6 +27,9 @@ namespace local_assessfreq\form;
 defined('MOODLE_INTERNAL') || die();
 
 require_once("$CFG->libdir/formslib.php");
+
+// Note - in Moodle 4.2+ this has moved, but this will still link
+// because of the db/renamedclasses.php linking.
 require_once($CFG->dirroot . '/mod/quiz/override_form.php');
 
 /**
@@ -53,6 +56,11 @@ class quiz_override_form extends \quiz_override_form {
         $this->groupmode = false;
         $this->groupid = 0;
         $this->userid = empty($override->userid) ? 0 : $override->userid;
+
+        // Required if MDL-80300 is backported (in core 4.4+).
+        if (property_exists($this, 'overrideid')) {
+            $this->overrideid = $override->id ?? 0;
+        }
 
         \moodleform::__construct(null, null, 'post', '', ['class' => 'ignoredirty'], true, $submitteddata);
     }


### PR DESCRIPTION
This adds compability if https://tracker.moodle.org/browse/MDL-80300 is backported. Mainly due to the `overrideid` being required, otherwise you get this error:

![Screenshot 2024-04-04 at 12-58-43 quiz1 - coursea - Dashboard](https://github.com/catalyst/moodle-local_assessfreq/assets/17095477/d51d9cf4-8d76-4558-bbd9-490af52c376b)

Note - I purposely did NOT update the class reference to the new namespaced `edit_override_form` class. This is to maintain compability with older versions (depending on backports). The `mod/quiz/db/renamedclasses.php` takes care of the linking under the hood.

Tested with this fix with backported tracker, and without backported tracker, and works.