### PR TITLE
Issue #159: Fixed CI-CD Unit test error "trailing junk after parameter"

### DIFF
--- a/classes/frequency.php
+++ b/classes/frequency.php
@@ -942,7 +942,7 @@ class frequency {
                       FROM {local_assessfreq_site} s
                  LEFT JOIN {course} c ON s.courseid = c.id
                      WHERE s.module $insql
-                           AND s.endyear = ?";
+                           AND s.endyear = ? ";
 
             $includehiddencourses = get_config('local_assessfreq', 'hiddencourses');
             if (!$includehiddencourses) {
@@ -995,7 +995,7 @@ class frequency {
                 INNER JOIN {local_assessfreq_user} u ON s.id = u.eventid
                 INNER JOIN {course} c ON s.courseid = c.id
                      WHERE s.module $insql
-                           AND s.endyear = ?";
+                           AND s.endyear = ? ";
 
             $includehiddencourses = get_config('local_assessfreq', 'hiddencourses');
             if (!$includehiddencourses) {
@@ -1044,7 +1044,7 @@ class frequency {
             $sql = 'SELECT s.module, COUNT(s.id) as count
                       FROM {local_assessfreq_site} s
                  LEFT JOIN {course} c ON s.courseid = c.id
-                     WHERE s.endyear = ?';
+                     WHERE s.endyear = ? ';
 
             $includehiddencourses = get_config('local_assessfreq', 'hiddencourses');
             if (!$includehiddencourses) {


### PR DESCRIPTION
Closes Issue #159 

Unit tests failing due to missing space between s.endyear = ? parameter and next SQL statement.

Error messages from failing tests:
```
local_assessfreq\frequency_test::test_get_events_due_by_month
dml_read_exception: Error reading from database (ERROR:  trailing junk after parameter at or near "$5G"
LINE 5:                            AND s.endyear = $5GROUP BY s.endm...
                                                   ^
SELECT s.endmonth, COUNT(s.id) as count
                      FROM phpu_local_assessfreq_site s
                 LEFT JOIN phpu_course c ON s.courseid = c.id
                     WHERE s.module IN ($1,$2,$3,$4)
                           AND s.endyear = $5GROUP BY s.endmonth
                     ORDER BY s.endmonth ASC
[array (
  0 => 'quiz',
  1 => 'assign',
  2 => 'scorm',
  3 => 'choice',
  4 => 2020,
)])

/var/www/moodle-44/lib/dml/moodle_database.php:494
/var/www/moodle-44/lib/dml/moodle_read_slave_trait.php:293
/var/www/moodle-44/lib/dml/pgsql_native_moodle_database.php:358
/var/www/moodle-44/lib/dml/pgsql_native_moodle_database.php:1044
/var/www/moodle-44/local/assessfreq/classes/frequency.php:956
/var/www/moodle-44/local/assessfreq/tests/frequency_test.php:693
/var/www/moodle-44/lib/phpunit/classes/advanced_testcase.php:72
```

```
local_assessfreq\frequency_test::test_get_events_due_by_activity
dml_read_exception: Error reading from database (ERROR:  trailing junk after parameter at or near "$1G"
LINE 4:                      WHERE s.endyear = $1GROUP BY s.module
                                               ^
SELECT s.module, COUNT(s.id) as count
                      FROM phpu_local_assessfreq_site s
                 LEFT JOIN phpu_course c ON s.courseid = c.id
                     WHERE s.endyear = $1GROUP BY s.module
                     ORDER BY s.module ASC
[array (
  0 => 2020,
)])

/var/www/moodle-44/lib/dml/moodle_database.php:494
/var/www/moodle-44/lib/dml/moodle_read_slave_trait.php:293
/var/www/moodle-44/lib/dml/pgsql_native_moodle_database.php:358
/var/www/moodle-44/lib/dml/pgsql_native_moodle_database.php:1044
/var/www/moodle-44/local/assessfreq/classes/frequency.php:1058
/var/www/moodle-44/local/assessfreq/tests/frequency_test.php:909
/var/www/moodle-44/lib/phpunit/classes/advanced_testcase.php:72
```

```
local_assessfreq\frequency_test::test_get_events_due_monthly_by_user
dml_read_exception: Error reading from database (ERROR:  trailing junk after parameter at or near "$5G"
LINE 6:                            AND s.endyear = $5GROUP BY s.endm...
                                                   ^
SELECT s.endmonth, COUNT(u.id) as count
                      FROM phpu_local_assessfreq_site s
                INNER JOIN phpu_local_assessfreq_user u ON s.id = u.eventid
                INNER JOIN phpu_course c ON s.courseid = c.id
                     WHERE s.module IN ($1,$2,$3,$4)
                           AND s.endyear = $5GROUP BY s.endmonth
                     ORDER BY s.endmonth ASC
[array (
  0 => 'quiz',
  1 => 'assign',
  2 => 'scorm',
  3 => 'choice',
  4 => 2020,
)])

/var/www/moodle-44/lib/dml/moodle_database.php:494
/var/www/moodle-44/lib/dml/moodle_read_slave_trait.php:293
/var/www/moodle-44/lib/dml/pgsql_native_moodle_database.php:358
/var/www/moodle-44/lib/dml/pgsql_native_mood/var/www/mwp-44/lib/dml/moodle_database.php:494le_database.php:1044
/var/www/moodle-44/local/assessfreq/classes/frequency.php:1009
/var/www/moodle-44/local/assessfreq/tests/frequency_test.php:973
/var/www/moodle-44/lib/phpunit/classes/advanced_testcase.php:72
```
After changes - output from the unit tests:
```
vendor/bin/phpunit local/assessfreq/tests/frequency_test.php
```
```
Moodle 4.1.14+ (Build: 20241122), 453877157fa82a59212d746def580eecb01e8c82
Php: 8.1.28, pgsql: 16.0 (Debian 16.0-1.pgdg120+1), OS: Linux 6.8.0-49-generic x86_64
PHPUnit 9.5.28 by Sebastian Bergmann and contributors.

...........................                                       27 / 27 (100%)

Time: 00:10.602, Memory: 103.50 MB

OK (27 tests, 161 assertions)
```
```
vendor/bin/phpunit local/assessfreq/tests/external_test.php
```
```
Moodle 4.1.14+ (Build: 20241122), 453877157fa82a59212d746def580eecb01e8c82
Php: 8.1.28, pgsql: 16.0 (Debian 16.0-1.pgdg120+1), OS: Linux 6.8.0-49-generic x86_64
PHPUnit 9.5.28 by Sebastian Bergmann and contributors.

..........                                                        10 / 10 (100%)

Time: 00:05.363, Memory: 105.00 MB

OK (10 tests, 38 assertions)
```
```
vendor/bin/phpunit local/assessfreq/tests/quiz_test.php
```
```
Moodle 4.1.14+ (Build: 20241122), 453877157fa82a59212d746def580eecb01e8c82
Php: 8.1.28, pgsql: 16.0 (Debian 16.0-1.pgdg120+1), OS: Linux 6.8.0-49-generic x86_64
PHPUnit 9.5.28 by Sebastian Bergmann and contributors.

.................                                                 17 / 17 (100%)

Time: 00:11.225, Memory: 100.50 MB

OK (17 tests, 82 assertions)
```