### PR TITLE
WR457626: Prune historic trend data

### DIFF
--- a/classes/task/prune_trend_data.php
+++ b/classes/task/prune_trend_data.php
@@ -1,0 +1,68 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace local_assessfreq\task;
+
+use core\task\scheduled_task;
+
+/**
+ * Prune older trend data points that will not be used in reports.
+ *
+ * Based on the trend limit set in the activity dashboard report, find any data points older than that and delete them.
+ *
+ * @package   local_assessfreq
+ * @copyright 2025 onwards Catalyst IT EU {@link https://catalyst-eu.net}
+ * @author    Mark Johnson <mark.johnson@catalyst-eu.net>
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class prune_trend_data extends scheduled_task {
+    #[\Override]
+    public function get_name() {
+        return get_string('task:prunetrenddata', 'local_assessfreq');
+    }
+
+    #[\Override]
+    public function execute(): void {
+        global $DB;
+        $trendlimit = get_config('assessfreqreport_activity_dashboard', 'trendlimit');
+        if (!$trendlimit) {
+            return;
+        }
+        // Find assessments with data to be pruned.
+        $assessments = $DB->get_recordset_sql(
+            "SELECT COUNT('x') AS datapoints, assessid, module
+               FROM {local_assessfreq_trend}
+           GROUP BY assessid, module
+             HAVING COUNT('x') > ?",
+            [$trendlimit],
+        );
+        foreach ($assessments as $assessment) {
+            // Find data points older than the limit, and delete them.
+            $pruneids = $DB->get_records(
+                'local_assessfreq_trend',
+                ['module' => $assessment->module, 'assessid' => $assessment->assessid],
+                'timecreated DESC, id DESC',
+                fields: 'id',
+                limitfrom: $trendlimit,
+            );
+            if (!empty($pruneids)) {
+                $DB->delete_records_list('local_assessfreq_trend', 'id', array_keys($pruneids));
+                mtrace("Pruned " . count($pruneids) . " data points for {$assessment->module} instance {$assessment->assessid}");
+            }
+        }
+        $assessments->close();
+    }
+}

--- a/db/tasks.php
+++ b/db/tasks.php
@@ -37,4 +37,13 @@ $tasks = [
         'dayofweek' => '*',
         'month' => '*',
     ],
+    [
+        'classname' => 'local_assessfreq\task\prune_trend_data',
+        'blocking' => 0,
+        'minute' => 'R',
+        'hour' => '*',
+        'day' => '*',
+        'dayofweek' => '*',
+        'month' => '*',
+    ],
 ];

--- a/tests/task/prune_trend_data_test.php
+++ b/tests/task/prune_trend_data_test.php
@@ -1,0 +1,84 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace local_assessfreq\task;
+
+/**
+ * Unit tests for prune_trend_data
+ *
+ * @package   local_assessfreq
+ * @copyright 2025 onwards Catalyst IT EU {@link https://catalyst-eu.net}
+ * @author    Mark Johnson <mark.johnson@catalyst-eu.net>
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @covers \local_assessfreq\task\prune_trend_data
+ */
+class prune_trend_data_test extends \advanced_testcase {
+    /**
+     * Test pruning old quiz trend data.
+     */
+    public function test_prune_quiz_trend_data(): void {
+        global $DB;
+        $this->resetAfterTest();
+
+        $now = 1594788000;
+
+        // Create a course with activity.
+        $generator = $this->getDataGenerator();
+        $course = $generator->create_course();
+
+        $quiz1 = $generator->create_module('quiz', [
+            'course' => $course->id,
+            'timeopen' => ($now - (3600 * 0.5)),
+            'timeclose' => ($now + (3600 * 0.5)),
+            'timelimit' => 3600,
+        ]);
+
+        $trackingtask = new \assessfreqsource_quiz\task\quiz_tracking();
+        // Generate data points for the quiz.
+        $trackingtask->execute();
+        $trackingtask->execute();
+        $trackingtask->execute();
+        $originaldatapoints = $DB->get_records('local_assessfreq_trend', ['assessid' => $quiz1->id, 'module' => 'quiz']);
+        // Create a second quiz.
+        $quiz2 = $generator->create_module('quiz', [
+            'course' => $course->id,
+            'timeopen' => ($now - (3600 * 0.5)),
+            'timeclose' => ($now + (3600 * 0.5)),
+            'timelimit' => 3600,
+        ]);
+        // Generate 5 additional data points for each quizzes.
+        $trackingtask->execute();
+        $trackingtask->execute();
+        $trackingtask->execute();
+        $trackingtask->execute();
+        $trackingtask->execute();
+
+        $this->assertEquals(8, $DB->count_records('local_assessfreq_trend', ['assessid' => $quiz1->id, 'module' => 'quiz']));
+        $this->assertEquals(5, $DB->count_records('local_assessfreq_trend', ['assessid' => $quiz2->id, 'module' => 'quiz']));
+
+        set_config('trendlimit', 5, 'assessfreqreport_activity_dashboard');
+        $prunetask = new prune_trend_data();
+
+        // The quiz with additional data points should be pruned down to the trend limit.
+        $this->expectOutputString("Pruned 3 data points for quiz instance {$quiz1->id}" . PHP_EOL);
+        $prunetask->execute();
+        $this->assertEquals(5, $DB->count_records('local_assessfreq_trend', ['assessid' => $quiz1->id, 'module' => 'quiz']));
+        $this->assertEquals(5, $DB->count_records('local_assessfreq_trend', ['assessid' => $quiz2->id, 'module' => 'quiz']));
+        // The older data points should be removed.
+        [$insql, $inparams] = $DB->get_in_or_equal(array_keys($originaldatapoints));
+        $this->assertFalse($DB->record_exists_select('local_assessfreq_trend', "id {$insql}", $inparams));
+    }
+}

--- a/version.php
+++ b/version.php
@@ -27,7 +27,7 @@ defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'local_assessfreq';
 $plugin->release = 2025032800;
-$plugin->version = 2025032800;
+$plugin->version = 2025040900;
 $plugin->requires = 2023100900; // Requires 4.3.
 $plugin->supported = [403, 405];
 $plugin->maturity = MATURITY_STABLE;


### PR DESCRIPTION
A new scheduled task that runs hourly to prune historic trend data.
Long-running assessments may generate a large number of trend data
points. We have a trendlimit setting to control how many points are
plotted, but additional points currently remain in the database. This
task allows points that will not be plotted to be periodically cleaned
up, reducing the table size and speeding up queries.